### PR TITLE
UDPBD Fixed Freeze

### DIFF
--- a/luckfox-pico/project/cfg/BoardConfig_IPC/overlay/overlay-luckfox-wifibt-firmware/etc/init.d/S99udpbd_sd
+++ b/luckfox-pico/project/cfg/BoardConfig_IPC/overlay/overlay-luckfox-wifibt-firmware/etc/init.d/S99udpbd_sd
@@ -1,33 +1,52 @@
 #!/bin/sh
 
+
+DEV="/dev/mmcblk0p1" 
+BIN="/usr/bin/udpbd-server"
+GPIO_PIN="34"
+
 case "$1" in
     start)
-	/usr/bin/udpbd-server /dev/mmcblk1 &
-	echo 34 > /sys/class/gpio/export
-	echo out > /sys/class/gpio/gpio34/direction
-	echo 1 > /sys/class/gpio/gpio34/value
-	sleep 0.3
-	echo 0 > /sys/class/gpio/gpio34/value
-	sleep 0.3
-	echo 1 > /sys/class/gpio/gpio34/value
-	sleep 0.3
-	echo 0 > /sys/class/gpio/gpio34/value
-	sleep 0.3
-	echo 1 > /sys/class/gpio/gpio34/value
-	sleep 0.3
-	echo 0 > /sys/class/gpio/gpio34/value
+        echo "Booting Up SD Server..."
+
+        (
+            
+            while ! ip addr show eth0 | grep -q "inet "; do
+                sleep 1
+            done
+
+            for i in 1 2 3 4 5 6 7 8 9 10; do
+                [ -b "$DEV" ] && break
+                sleep 1
+            done
+
+            if [ -b "$DEV" ]; then
+                sysctl -w net.core.rmem_max=26214400 >/dev/null 2>&1
+                sysctl -w net.core.wmem_max=26214400 >/dev/null 2>&1
+                if [ -e /sys/devices/system/cpu/cpufreq/policy0/scaling_governor ]; then
+                    echo performance > /sys/devices/system/cpu/cpufreq/policy0/scaling_governor
+                fi
+
+                killall -9 $(basename $BIN) >/dev/null 2>&1
+                nice -n -20 $BIN "$DEV" > /dev/null 2>&1 &
+                
+                if [ ! -d "/sys/class/gpio/gpio$GPIO_PIN" ]; then
+                    echo $GPIO_PIN > /sys/class/gpio/export 2>/dev/null
+                fi
+                echo out > "/sys/class/gpio/gpio$GPIO_PIN/direction"
+                for i in 1 0 1 0; do
+                    echo $i > "/sys/class/gpio/gpio$GPIO_PIN/value"
+                    sleep 0.2
+                done
+            fi
+        ) &
         ;;
     stop)
-        echo "Stopping..."
-        ;;
-    restart)
-        $0 stop
-        $0 start
+        killall -9 $(basename $BIN) >/dev/null 2>&1
         ;;
     *)
-        echo "Usage: $0 {start|stop|restart}"
+        echo "Usage: $0 {start|stop}"
         exit 1
         ;;
 esac
-
 exit 0

--- a/luckfox-pico/project/cfg/BoardConfig_IPC/overlay/overlay-luckfox-wifibt-firmware/etc/init.d/S99udpbd_usb
+++ b/luckfox-pico/project/cfg/BoardConfig_IPC/overlay/overlay-luckfox-wifibt-firmware/etc/init.d/S99udpbd_usb
@@ -1,37 +1,52 @@
 #!/bin/sh
 
+
+DEV="/dev/sda1"
+BIN="/usr/bin/udpbd-server"
+GPIO_PIN="34"
+
 case "$1" in
     start)
-        /usr/bin/udpbd-server-c /dev/sda1 &
-	echo 34 > /sys/class/gpio/export
-	echo out > /sys/class/gpio/gpio34/direction
-	echo 1 > /sys/class/gpio/gpio34/value
-	sleep 0.3
-	echo 0 > /sys/class/gpio/gpio34/value
-	sleep 0.3
-	echo 1 > /sys/class/gpio/gpio34/value
-	sleep 0.3
-	echo 0 > /sys/class/gpio/gpio34/value
-	sleep 0.3
-	echo 1 > /sys/class/gpio/gpio34/value
-	sleep 0.3
-	echo 0 > /sys/class/gpio/gpio34/value
-	sleep 0.3
-	echo 1 > /sys/class/gpio/gpio34/value
-	sleep 0.3
-	echo 0 > /sys/class/gpio/gpio34/value
+        echo "Booting Up USB Server..."
+
+        (
+            
+            while ! ip addr show eth0 | grep -q "inet "; do
+                sleep 1
+            done
+
+            for i in 1 2 3 4 5 6 7 8 9 10; do
+                [ -b "$DEV" ] && break
+                sleep 1
+            done
+
+            if [ -b "$DEV" ]; then
+                sysctl -w net.core.rmem_max=26214400 >/dev/null 2>&1
+                sysctl -w net.core.wmem_max=26214400 >/dev/null 2>&1
+                if [ -e /sys/devices/system/cpu/cpufreq/policy0/scaling_governor ]; then
+                    echo performance > /sys/devices/system/cpu/cpufreq/policy0/scaling_governor
+                fi
+
+                killall -9 $(basename $BIN) >/dev/null 2>&1
+                nice -n -20 $BIN "$DEV" > /dev/null 2>&1 &
+                
+                if [ ! -d "/sys/class/gpio/gpio$GPIO_PIN" ]; then
+                    echo $GPIO_PIN > /sys/class/gpio/export 2>/dev/null
+                fi
+                echo out > "/sys/class/gpio/gpio$GPIO_PIN/direction"
+                for i in 1 0 1 0; do
+                    echo $i > "/sys/class/gpio/gpio$GPIO_PIN/value"
+                    sleep 0.2
+                done
+            fi
+        ) &
         ;;
     stop)
-        echo "Stopping..."
-        ;;
-    restart)
-        $0 stop
-        $0 start
+        killall -9 $(basename $BIN) >/dev/null 2>&1
         ;;
     *)
-        echo "Usage: $0 {start|stop|restart}"
+        echo "Uso: $0 {start|stop}"
         exit 1
         ;;
 esac
-
 exit 0


### PR DESCRIPTION
## Description
This PR addresses unexpected game freezes/stalls during gameplay (especially during heavy loading sequences or FMVs) when running `udpbd-server` on resource-constrained embedded devices like the **Luckfox Pico Plus**. 

The original script started the server immediately without waiting for dependencies, which led to race conditions and packet loss due to default OS network settings and aggressive CPU power saving.

## Changes Introduced
* **Network Buffer Optimization:** Increased `net.core.rmem_max` and `wmem_max` to ensure UDP packets are not dropped under heavy load.
* **CPU Governor Tweaks:** Forced the CPU governor to `performance` mode to eliminate CPU scaling latencies that trigger PS2 storage timeouts.
* **Network & Storage Guardrails:** Added loop checks (`while` / `for`) to ensure `eth0` has a valid IP address and the storage device is fully populated before starting the binary.
* **Clean Process Management:** Added a proactive `killall -9` before launch to prevent duplicate background instances, and set process priority to maximum (`nice -n -20`).
* **Refactored Code:** Cleaned up the GPIO blinking logic using a compact `for` loop and centralized path variables for easier maintenance.

## Testing
Tested on Luckfox Pico Plus. Games that previously suffered from random freezes now run smoothly, and the network performance is significantly more stable.